### PR TITLE
Added NuGet.config for initial project restore

### DIFF
--- a/src/NuGet.config
+++ b/src/NuGet.config
@@ -1,0 +1,5 @@
+<configuration>
+    <packageSources>
+        <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    </packageSources>
+</configuration>


### PR DESCRIPTION
When cloning the repo and attempting to restore/publish the projects, dotnet throws an error about not being able to restore the packages. Adding a basic nuget config allows it to work through everything normally, and saves a minor headache for new folks cloning the project and working with it.